### PR TITLE
Domain.prototype.is_member typo variable name

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -29,7 +29,7 @@ Domain.prototype.toString = function() {
 
 Domain.prototype.is_member = function(v) {
 	var d1 = this
-	return v>=d.min && v<=d.max
+	return v>=d1.min && v<=d1.max
 }
 
 Domain.prototype.add = function(d2) {


### PR DESCRIPTION
Got there from hackernews, spotted this typo right away. Consider eslinting your codebase.
